### PR TITLE
Enforce Ruby version in gemspec.

### DIFF
--- a/lib/society.rb
+++ b/lib/society.rb
@@ -12,8 +12,6 @@ require_relative "society/formatter/report/json"
 require_relative "society/parser"
 require_relative "society/version"
 
-raise 'Ruby version must be greater than 2.0' unless RUBY_VERSION.to_f > 2.0
-
 module Society
 
   def self.new(*paths_to_files)

--- a/society.gemspec
+++ b/society.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.1"
+
   spec.add_dependency "activesupport"
   spec.add_dependency "analyst", ">= 1.0.0"
   spec.add_dependency "parser"


### PR DESCRIPTION
- user is alerted to Ruby version dependency on attempted gem install,
not on first attempted use