### PR TITLE
Adds globbing support

### DIFF
--- a/lib/society/parser.rb
+++ b/lib/society/parser.rb
@@ -13,7 +13,7 @@ module Society
     #
     # Returns a Parser.
     def self.for_files(*file_paths)
-      files = file_paths.flatten.flat_map do |path|
+      files = Dir.glob(file_paths).flatten.flat_map do |path|
         File.directory?(path) ? Dir.glob(File.join(path, '**', '*.rb')) : path
       end
       new(files.lazy.map { |f| File.read(f) })
@@ -489,4 +489,3 @@ module Society
   end
 
 end
-

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -205,6 +205,9 @@ describe Society::Parser do
       expect(Society::Parser.for_files('./spec/fixtures/for_parser_spec').classes).to eq(["Whaler"])
     end
 
+    it "returns a parser object when given a glob" do
+      expect(Society::Parser.for_files("#{Dir.getwd}/lib/society/{parser.rb,node.rb}").classes).to eq(["Society", "Society::Parser", "Society::Node"])
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
... though globs have to be specified in quotes.

So instead of

`society from PATH`

we need

`society from "the/path/{to,glob}"`.

Maybe someone else can figure out how to eliminate the quotes. But this works for my needs for now. I hope it helps someone else too!