### PR TITLE
Hiding nodes and links not involved in the clicked on node

### DIFF
--- a/lib/society/formatter/report/templates/components/society-assets/society.js
+++ b/lib/society/formatter/report/templates/components/society-assets/society.js
@@ -20,7 +20,6 @@
 
     this.element = element;
     this.data = this.transformData(data);
-    this.origData = this.data;
     this.includeIsolatedNodes = true;
     this.depsFiltered = false;
   };

--- a/lib/society/formatter/report/templates/components/society-assets/society.js
+++ b/lib/society/formatter/report/templates/components/society-assets/society.js
@@ -20,7 +20,9 @@
 
     this.element = element;
     this.data = this.transformData(data);
+    this.origData = this.data;
     this.includeIsolatedNodes = true;
+    this.depsFiltered = false;
   };
 
   NetworkGraph.prototype.transformData = function(data) {
@@ -130,6 +132,26 @@
           .classed("society-node--source", false);
     };
 
+    var toggleFilterOnlyDeps = function(d) {
+      if (this.depsFiltered == false) {
+	nodeAnchor.selectAll(".society-node--faded")
+	  .style("visibility", "hidden");
+	linkAnchor.selectAll(".society-link")
+	  .filter(":not(.society-link--source)")
+	  .filter(":not(.society-link--target)")
+	  .style("visibility", "hidden");
+	this.depsFiltered = true;
+      } else {
+	d3
+	  .selectAll(".society-node")
+	  .style("visibility", "visible");
+	d3
+	  .selectAll(".society-link")
+	  .style("visibility", "visible");
+	this.depsFiltered = false;
+      }
+    };
+
     var newNodes = node.enter().append("text")
       .attr("opacity", 0)
       .attr("transform", function(d) { return "rotate(" + (d.x - 90) + ")translate(" + (d.y + 64) + ",0)" + (d.x < 180 ? "" : "rotate(180)"); })
@@ -138,7 +160,8 @@
       .attr("dy", ".31em")
       .text(function(d) { return d.key; })
       .on("mouseover", mouseovered)
-      .on("mouseout", mouseouted);
+      .on("mouseout", mouseouted)
+      .on("click", toggleFilterOnlyDeps);
 
     link.enter().append("path")
       .attr("opacity", 0)


### PR DESCRIPTION
I was trying to reduce the noise introduced by having a lot of classes in the same society graph. Right now, this is only tweaking styles and not the actual data so the node layout is unchanged. Dependent nodes still have a tendency to overlap but removing nodes uninvolved in the clicked node still tends to make the graph easier to read.