### PR TITLE
Center the selection control on the page, the same as title

### DIFF
--- a/lib/society/formatter/report/templates/components/society-assets/society.css
+++ b/lib/society/formatter/report/templates/components/society-assets/society.css
@@ -28,6 +28,7 @@
   font-size: 14px;
   line-height: 1.42857143;
   background-image: none;
+  margin: auto;
 }
 
 .society-network-toggle input {


### PR DESCRIPTION
# Before
![screen shot 2016-03-16 at 2 07 07 pm](https://cloud.githubusercontent.com/assets/334809/13828743/67e3ee0e-eb80-11e5-817f-32a89d74ffe5.png)

# After

![screen shot 2016-03-16 at 2 07 11 pm](https://cloud.githubusercontent.com/assets/334809/13828744/67e57d46-eb80-11e5-8a78-9d1b51864557.png)
